### PR TITLE
Fix duplicated HTML and make page validator compliant

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -1,37 +1,25 @@
-<!DOCTYPE html>
-<html>
+<button onclick="window.location.reload()">Run Program</button>
+<div id="terminal"></div>
 
-<head>
-    <meta charset="utf-8" />
-    <title>Python Terminal by Code Institute</title>
-</head>
+<script>
+    var term = new Terminal({
+        cols: 80,
+        rows: 24
+    });
+    term.open(document.getElementById('terminal'));
+    term.writeln('Running startup command: python3 run.py');
+    term.writeln('');
 
-<body>
-    <button onclick="window.location.reload()">Run Program</button>
-    <div id="terminal"></div>
+    var ws = new WebSocket(location.protocol.replace('http', 'ws') + '//' + location.hostname + (location.port ? (
+        ':' + location.port) : '') + '/');
 
-    <script>
-        var term = new Terminal({
-            cols: 80,
-            rows: 24
-        });
-        term.open(document.getElementById('terminal'));
-        term.writeln('Running startup command: python3 run.py');
-        term.writeln('');
+    ws.onopen = function () {
+        new attach.attach(term, ws);
+    };
 
-        var ws = new WebSocket(location.protocol.replace('http', 'ws') + '//' + location.hostname + (location.port ? (
-            ':' + location.port) : '') + '/');
-
-        ws.onopen = function () {
-            new attach.attach(term, ws);
-        };
-
-        ws.onerror = function (e) {
-            console.log(e);
-        };
-        // Set focus in the terminal
-        document.getElementsByClassName("xterm-helper-textarea")[0].focus();
-    </script>
-</body>
-
-</html>
+    ws.onerror = function (e) {
+        console.log(e);
+    };
+    // Set focus in the terminal
+    document.getElementsByClassName("xterm-helper-textarea")[0].focus();
+</script>

--- a/views/index.html
+++ b/views/index.html
@@ -3,8 +3,6 @@
 
 <head>
     <meta charset="utf-8" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xterm/3.14.5/xterm.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xterm/3.14.5/addons/attach/attach.js"></script>
     <title>Python Terminal by Code Institute</title>
 </head>
 

--- a/views/layout.html
+++ b/views/layout.html
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Python Terminal by Code Institute</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xterm/3.14.5/xterm.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xterm/3.14.5/addons/attach/attach.js"></script>

--- a/views/layout.html
+++ b/views/layout.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
     <meta charset="utf-8" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
@@ -165,11 +164,7 @@
         }
     </style>
 </head>
-
 <body>
-
     <div>@{body}</div>
-
 </body>
-
 </html>

--- a/views/layout.html
+++ b/views/layout.html
@@ -4,6 +4,8 @@
 <head>
     <meta charset="utf-8" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xterm/3.14.5/xterm.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xterm/3.14.5/addons/attach/attach.js"></script>
     @{import('head', 'meta')}
     <style>
         body {


### PR DESCRIPTION
The current layout.html embeds all of index.html in the @{body} element, including the DOCTYPE, html, head and body tags, making the page have duplicates of all of these elements.
Stripped all these out of index.html so it's just the end HTML code remaining.
Also added html language definition and updated meta tags so the page is compliant with the W3C validator.