### PR TITLE
feat: Add helper program to print terminal size

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ Connect your GitHub repository and deploy as normal.
 
 ## Constraints
 
-The deployment terminal is set to 80 columns by 24 rows. That means that each line of text needs to be 80 characters or less otherwise it will be wrapped onto a second line.
+The deployment terminal is set to 80 columns by 24 rows. That means that each line of text needs to be 80 characters or less otherwise it will be wrapped onto a second line.  
+
+We have created a program to print the size of the deployment terminal to help you.
+You may wish to resize a terminal window to the size of the printed output.
+
+To run the program, use the command `python3 -m terminal_size`.
 
 -----
 Happy coding!

--- a/terminal_size.py
+++ b/terminal_size.py
@@ -1,0 +1,13 @@
+"""Prints a 24 x 80 container to indicate terminal size"""
+
+
+def display_terminal_size():
+
+    print("-"*80)
+    for i in range(23):
+        print("|"+" "*78+"|")
+    print("-"*80)
+
+
+if __name__ == "__main__":
+    display_terminal_size()


### PR DESCRIPTION
Notes added in README as to how to use. This allows students a
stress-free quick method to help them size their terminal correctly and
view their projects as they will render once on Heroku.